### PR TITLE
add attribute function support

### DIFF
--- a/hashindex/hashindex.py
+++ b/hashindex/hashindex.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, List, Any, Dict, Set
+from typing import Iterable, Optional, List, Any, Dict, Set, Callable, Union
 
 from hashindex.exceptions import MissingIndexError, FrozenError
 from hashindex.mutable import MutableIndex
@@ -6,7 +6,7 @@ from hashindex.frozen import FrozenIndex
 
 
 class HashIndex:
-    def __init__(self, fields: Iterable[str]):
+    def __init__(self, fields: Iterable[Union[str, Callable]]):
         self.index = MutableIndex(fields)
         self.frozen = False
 

--- a/hashindex/mutable.py
+++ b/hashindex/mutable.py
@@ -1,8 +1,8 @@
-from typing import Optional, List, Any, Dict, Set
-
+from typing import Optional, List, Any, Dict, Set, Callable, Union
 from cykhash import Int64Set
 
 from hashindex.exceptions import MissingObjectError, MissingIndexError
+from hashindex.utils import get_field
 
 
 class MutableIndex:
@@ -20,8 +20,8 @@ class MutableIndex:
 
     def find(
         self,
-        match: Optional[Dict[str, Any]] = None,
-        exclude: Optional[Dict[str, Any]] = None,
+        match: Optional[Dict[Optional[Union[str, Callable]], Any]] = None,
+        exclude: Optional[Dict[Optional[Union[str, Callable]], Any]] = None,
     ) -> List:
         hits = self.find_ids(match, exclude)
         if isinstance(self.objs, dict):
@@ -31,8 +31,8 @@ class MutableIndex:
 
     def find_ids(
         self,
-        match: Optional[Dict[str, Any]] = None,
-        exclude: Optional[Dict[str, Any]] = None,
+        match: Optional[Dict[Optional[Union[str, Callable]], Any]] = None,
+        exclude: Optional[Dict[Optional[Union[str, Callable]], Any]] = None,
     ) -> Set:
         """
         Perform lookup based on given values. Return a set of object IDs matching constraints.
@@ -82,9 +82,8 @@ class MutableIndex:
     def add(self, obj):
         ptr = id(obj)
         self.objs[ptr] = obj
-
         for field in self.indices:
-            val = obj.__dict__.get(field, None)
+            val = get_field(obj, field)  # TODO add this to the others too, let's have a party
             self._add_to_field_index(ptr, field, val)
 
     def remove(self, obj):

--- a/hashindex/utils.py
+++ b/hashindex/utils.py
@@ -1,0 +1,8 @@
+def get_field(obj, field):
+    if callable(field):
+        val = field(obj)
+    elif isinstance(obj, dict):
+        val = obj.get(field, None)
+    else:
+        val = getattr(obj, field, None)
+    return val

--- a/perf_test/planning.ipynb
+++ b/perf_test/planning.ipynb
@@ -13,6 +13,8 @@
     " - Performance graphs (ram, speed)\n",
     " - Replace dict(set()) with dict(cykhash())\n",
     "\n",
+    "Cool idea:\n",
+    " - Custom getter functions. Don't just get attribute. Get by (lambda x: x['thing'][0].message) or whatever.\n",
     "\n",
     "Deeper optimizations:\n",
     "  + Query planning\n",
@@ -38,8 +40,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "bde9c574",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{<function first_three_letters at 0x7f8c0042a160>: 'str'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def first_three_letters(x: str):\n",
+    "    return x[:3]\n",
+    "\n",
+    "on = {first_three_letters: 'str'}\n",
+    "print(on)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f2bf0db",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def freeze(request):
+    return request.param

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from hashindex import HashIndex, get_attributes
+import unittest
 
+from hashindex import HashIndex, get_attributes
+from hashindex.exceptions import FrozenError
 
 @dataclass
 class Pokemon:
@@ -16,7 +18,7 @@ class Pokemon:
         return f"{self.name}: {self.type1}/{self.type2}"
 
 
-def make_test_data():
+def make_test_data(freeze):
     zapdos = Pokemon("Zapdos", "Electric", "Flying")
     pikachu_1 = Pokemon("Pikachu", "Electric", None)
     pikachu_2 = Pokemon("Pikachu", "Electric", None)
@@ -26,23 +28,25 @@ def make_test_data():
     mi.add(pikachu_1)
     mi.add(pikachu_2)
     mi.add(eevee)
+    if freeze:
+        mi.freeze()
     return mi
 
 
-def test_find_one():
-    mi = make_test_data()
+def test_find_one(freeze):
+    mi = make_test_data(freeze)
     result = mi.find({"name": ["Zapdos"]})
     assert len(result) == 1
 
 
-def test_find_match():
-    mi = make_test_data()
+def test_find_match(freeze):
+    mi = make_test_data(freeze)
     result = mi.find({"name": ["Pikachu", "Eevee"]})
     assert len(result) == 3
 
 
-def test_find_excluding():
-    mi = make_test_data()
+def test_find_excluding(freeze):
+    mi = make_test_data(freeze)
     result = mi.find(
         match=None, exclude={"type2": None}
     )  # Zapdos is the only one with a type2
@@ -50,44 +54,8 @@ def test_find_excluding():
     assert result[0].name == "Zapdos"
 
 
-def test_remove():
-    mi = make_test_data()
-    two_chus = mi.find({"name": "Pikachu"})
-    assert len(two_chus) == 2
-    mi.remove(two_chus[1])
-    one_chu = mi.find({"name": "Pikachu"})
-    assert len(one_chu) == 1
-
-
-def test_update():
-    mi = make_test_data()
-    eevee = mi.find({"name": "Eevee"})[0]
-    mi.update(eevee, {"name": "Jolteon", "type1": "Electric", "type2": None})
-    res_eevee = mi.find({"name": "Eevee"})
-    res_jolteon = mi.find({"name": "Jolteon"})
-    assert not res_eevee
-    assert res_jolteon
-
-
-def test_find_freezing():
-    mi = make_test_data()
-    mi.freeze()
-    result = mi.find({"name": ["Pikachu", "Eevee"]})
-    assert len(result) == 3
-
-
-def test_exclude_freezing():
-    mi = make_test_data()
-    mi.freeze()
-    result = mi.find(
-        match=None, exclude={"type2": None}
-    )  # Zapdos is the only one with a type2
-    assert len(result) == 1
-    assert result[0].name == "Zapdos"
-
-
-def test_another():
-    mi = make_test_data()
+def test_another(freeze):
+    mi = make_test_data(freeze)
     result = mi.find(
         match={"name": ["Pikachu", "Zapdos"], "type1": "Electric"},
         exclude={"type2": "Flying"},
@@ -97,13 +65,44 @@ def test_another():
     assert result[1].name == "Pikachu"
 
 
-def test_another_freeze():
-    mi = make_test_data()
-    mi.freeze()
-    result = mi.find(
-        match={"name": ["Pikachu", "Zapdos"], "type1": "Electric"},
-        exclude={"type2": "Flying"},
-    )
-    assert len(result) == 2
-    assert result[0].name == "Pikachu"
-    assert result[1].name == "Pikachu"
+class TestMutations(unittest.TestCase):
+
+    def test_remove(self):
+        for freeze in [False, True]:
+            mi = make_test_data(freeze)
+            two_chus = mi.find({"name": "Pikachu"})
+            assert len(two_chus) == 2
+            if freeze:
+                with self.assertRaises(FrozenError):
+                    mi.remove(two_chus[1])
+            else:
+                mi.remove(two_chus[1])
+                one_chu = mi.find({"name": "Pikachu"})
+                assert len(one_chu) == 1
+
+    def test_update(self,):
+        for freeze in [False, True]:
+            mi = make_test_data(freeze)
+            eevee = mi.find({"name": "Eevee"})[0]
+            update = {"name": "Glaceon", "type1": "Ice", "type2": None}
+            if freeze:
+                with self.assertRaises(FrozenError):
+                    mi.update(eevee, update)
+            else:
+                mi.update(eevee, update)
+                res_eevee = mi.find({"name": "Eevee"})
+                res_glaceon = mi.find({"name": "Glaceon"})
+                assert not res_eevee
+                assert res_glaceon
+
+    def test_add_frozen(self):
+        for freeze in [False, True]:
+            mi = make_test_data(freeze)
+            glaceon = Pokemon("Glaceon", "Ice", None)
+            if freeze:
+                with self.assertRaises(FrozenError):
+                    mi.add(glaceon)
+            else:
+                mi.add(glaceon)
+                res = mi.find({"name": "Glaceon"})
+                assert res == [glaceon]

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -2,3 +2,4 @@
 # Can we correctly match / mismatch None values?
 # Does the `set` / `tuple` conversion work properly?
 # What happens when the user forgets to remove an object?
+# What if I add an object twice?

--- a/test/test_fancy_gets.py
+++ b/test/test_fancy_gets.py
@@ -1,0 +1,52 @@
+"""
+Test attribute lookups of different kinds
+e.g. getting dict attributes, or applying functions, or getting properties from namedtuples
+"""
+
+from hashindex import HashIndex
+
+
+def make_dict_data():
+    dicts = [
+        {
+            't0': 0.1,
+            't1': 0.2,
+            's': 'ABC',
+        },
+        {
+            't0': 0.3,
+            't1': 0.4,
+            's': 'DEF',
+        },
+        {
+            't0': 0.5,
+            't1': 0.6,
+            's': 'GHI',
+        }
+    ]
+    return dicts
+
+
+def test_dicts(freeze):
+    dicts = make_dict_data()
+    hi = HashIndex(['t0', 't1', 's'])
+    for d in dicts:
+        hi.add(d)
+    if freeze:
+        hi.freeze()
+    result = hi.find(match={'t0': [0.1, 0.3], 's': ['ABC', 'DEF']}, exclude={'t1': 0.4})
+    assert result == [dicts[0]]
+
+
+def test_getter_fn(freeze):
+    def _middle_letter(obj):
+        return obj['s'][1]
+
+    dicts = make_dict_data()
+    hi = HashIndex([_middle_letter])
+    for d in dicts:
+        hi.add(d)
+    if freeze:
+        hi.freeze()
+    result = hi.find({_middle_letter: 'H'})
+    assert result == [dicts[2]]


### PR DESCRIPTION
What if your attribute is some nested thinger? Like `obj.x[2]` or `obj.d['thing'].status`?

Or what if you want to index on a computed attribute, like `obj.x + obj.y`?

Now you can do both, with attribute functions. This is so cool.

```
def my_function(obj):
    return obj['s'][1]
hi = HashIndex([my_function])
# ... add data
hi.find({my_function: 'value'})
```