### PR TITLE
0.5.1 - fix ram underperformance

### DIFF
--- a/docs/data_structures.md
+++ b/docs/data_structures.md
@@ -1,4 +1,15 @@
-# Design
+# Data Structures
+
+## Overview
+
+ - HashIndex [mutable.py](hashindex/mutable.py)
+    - MutableFieldIndex
+      - HashBucket
+      - DictBucket
+ - FrozenHashIndex
+   - FrozenFieldIndex
+     - FHashBucket
+     - FDictBucket
 
 ### HashIndex - main class
 

--- a/hashindex/exceptions.py
+++ b/hashindex/exceptions.py
@@ -24,4 +24,5 @@ class MissingObjectError(Exception):
 
 class StaleObjectRemovalError(Exception):
     """Raised when attempting to remove an object that was modified elsewhere."""
+
     pass

--- a/hashindex/frozen.py
+++ b/hashindex/frozen.py
@@ -15,9 +15,7 @@ class FrozenHashIndex:
                 "Cannot build an empty FrozenHashIndex; at least 1 object is required."
             )
         if not on:
-            raise ValueError(
-                "Need at least one field to index on."
-            )
+            raise ValueError("Need at least one field to index on.")
         self.on = on
         self.indices = {}
         for field in on:
@@ -104,4 +102,3 @@ class FrozenHashIndex:
     def __len__(self):
         for idx in self.indices.values():
             return len(idx)
-

--- a/hashindex/frozen_buckets.py
+++ b/hashindex/frozen_buckets.py
@@ -120,7 +120,6 @@ class FDictBucket:
 
 
 class FHashBucketIterator:
-
     def __init__(self, fhb: FHashBucket):
         self.arr = fhb.array_pair.obj_arr
         self.i = 0
@@ -134,9 +133,10 @@ class FHashBucketIterator:
 
 
 class FDictBucketIterator:
-
     def __init__(self, fdb: FDictBucket):
-        self.arrs = list(arr_pair.obj_arr for arr_pair in fdb.d.values() if len(arr_pair) > 0)
+        self.arrs = list(
+            arr_pair.obj_arr for arr_pair in fdb.d.values() if len(arr_pair) > 0
+        )
         self.i = 0
         self.j = 0
 

--- a/hashindex/frozen_field.py
+++ b/hashindex/frozen_field.py
@@ -53,7 +53,6 @@ class FrozenFieldIndex:
 
 
 class FrozenFieldIndexIterator:
-
     def __init__(self, ffi: FrozenFieldIndex):
         self.buckets = ffi.buckets
         self.i = 0

--- a/hashindex/init_helpers.py
+++ b/hashindex/init_helpers.py
@@ -150,4 +150,3 @@ def compute_buckets(objs, field, bucket_size_limit):
         )
 
     return bucket_plans
-

--- a/hashindex/mutable.py
+++ b/hashindex/mutable.py
@@ -16,9 +16,7 @@ class HashIndex:
         on: Iterable[Union[str, Callable]] = None,
     ):
         if not on:
-            raise ValueError(
-                "Need at least one field to index on."
-            )
+            raise ValueError("Need at least one field to index on.")
         if objs:
             self.obj_map = {id(obj): obj for obj in objs}
         else:

--- a/hashindex/mutable.py
+++ b/hashindex/mutable.py
@@ -4,7 +4,7 @@ from cykhash import Int64Set
 from operator import itemgetter
 from hashindex.constants import SIZE_THRESH
 from hashindex.exceptions import MissingObjectError, MissingIndexError
-from hashindex.utils import set_field, validate_query
+from hashindex.utils import validate_query
 from hashindex.init_helpers import compute_buckets
 from hashindex.mutable_field import MutableFieldIndex
 
@@ -109,13 +109,6 @@ class HashIndex:
         for field in self.indices:
             self.indices[field].remove(ptr, obj)
         del self.obj_map[ptr]
-
-    def update(self, obj, new_values: dict):
-        """Change the indexed values for obj to the new values specified. Also updates the values of obj."""
-        self.remove(obj)
-        for field, new_value in new_values.items():
-            set_field(obj, field, new_value)
-        self.add(obj)
 
     def _match_any_of(self, field: str, value: Any):
         """Get matches for a single field during a find(). If multiple values specified, handle union logic."""

--- a/hashindex/mutable_bucket_manager.py
+++ b/hashindex/mutable_bucket_manager.py
@@ -13,7 +13,6 @@ So it's in a separate class to help manage the complexity and provide easy testi
 
 
 class MutableBucketManager:
-
     def __init__(self):
         self.buckets = SortedDict()
 
@@ -30,7 +29,9 @@ class MutableBucketManager:
             del self.buckets[bkey]
         else:
             # Case 2: The left neighbor is nonexistent, or is a DictBucket. Let's look right.
-            if right_key is not None and isinstance(self.buckets[right_key], HashBucket):
+            if right_key is not None and isinstance(
+                self.buckets[right_key], HashBucket
+            ):
                 # Case 2a. The right neighbor is a hash bucket. We can expand it leftwards to cover the gap.
                 b = self.buckets[right_key]
                 del self.buckets[right_key]
@@ -53,7 +54,7 @@ class MutableBucketManager:
         if bkey == HASH_MIN:
             left_key = None
         else:
-            left_idx = self.buckets.bisect_left(bkey)-1
+            left_idx = self.buckets.bisect_left(bkey) - 1
             if left_idx < 0:
                 # this can happen if the bucket at HASH_MIN was just deleted and we're
                 # about to make a new neighbor for it.

--- a/hashindex/mutable_buckets.py
+++ b/hashindex/mutable_buckets.py
@@ -1,6 +1,6 @@
-from typing import Dict, Any, Union, Iterable, Callable, Optional
+from typing import Dict, Any, Union, Iterable, Callable, Optional, Tuple
 
-from cykhash import Int64Set, Int64toInt64Map
+from cykhash import Int64Set
 
 from hashindex.utils import get_field
 
@@ -15,56 +15,61 @@ class HashBucket:
     """
 
     def __init__(
-        self, obj_ids: Int64Set = None, val_hash_counts: Int64toInt64Map = None
+        self, obj_ids: Int64Set = None
     ):
         self.obj_ids = obj_ids if obj_ids else Int64Set()
-        self.val_hash_counts = val_hash_counts if val_hash_counts else Int64toInt64Map()
 
-    def add(self, val_hash, obj_id):
-        count = self.val_hash_counts.get(val_hash, 0)
-        self.val_hash_counts[val_hash] = count + 1
+    def add(self, obj_id):
         self.obj_ids.add(obj_id)
-
-    def update(self, new_val_hash_counts, new_obj_ids):
-        for v, c in new_val_hash_counts.items():
-            count = self.val_hash_counts.get(v, 0)
-            self.val_hash_counts[v] = count + c
-        self.obj_ids = self.obj_ids.union(new_obj_ids)
 
     def get_all_ids(self):
         return self.obj_ids
 
-    def remove(self, val_hash, obj_id):
-        if val_hash not in self.val_hash_counts or self.val_hash_counts[val_hash] <= 0:
-            raise StaleObjectRemovalError(
-                f"Cannot remove object (not found). Object was changed without using update()."
-            )
-        self.val_hash_counts[val_hash] -= 1
-        if self.val_hash_counts[val_hash] == 0:
-            del self.val_hash_counts[val_hash]
+    def remove(self, _, obj_id):
         self.obj_ids.remove(obj_id)
 
-    def split(self, field, obj_map: Dict[int, Any]):
-        my_hashes = list(sorted(self.val_hash_counts.keys()))
-        # dump out the upper half of our hashes
+    def dump_some_out_maybe(self, field, obj_map: Dict[int, Any]) -> Tuple[Optional[Int64Set],
+                                                                           Optional[int],
+                                                                           Optional[Dict[int, Int64Set]]]:
+        """
+        When a hashbucket is overfilled, dump some out maybe.
+
+        Or maybe we only have 1 unique hash, and this should be a dictbucket.
+        Returns (dumped_ids, None) or (None, dict_for_a_dict_bucket), depending.
+        """
+        val_to_obj_ids = dict()
+        val_hash_to_obj_ids = dict()
+        for obj_id in self.obj_ids:
+            val = get_field(obj_map[obj_id], field)
+            if len(val_hash_to_obj_ids) < 2:
+                # add to val dict, as long as we still think this might become a DictBucket
+                if val not in val_to_obj_ids:
+                    val_to_obj_ids[val] = Int64Set()
+                val_to_obj_ids[val].add(obj_id)
+            # add to val_hash dict
+            val_hash = hash(val)
+            if val_hash not in val_hash_to_obj_ids:
+                val_hash_to_obj_ids[val_hash] = Int64Set()
+            val_hash_to_obj_ids[val_hash].add(obj_id)
+
+        if len(val_hash_to_obj_ids) == 1:
+            # looks like a dictbucket
+            return None, None, val_to_obj_ids
+
+        my_hashes = list(sorted(val_hash_to_obj_ids.keys()))
+
+        # dump out the upper half the hash values
         half_point = len(my_hashes) // 2
-        dumped_hash_counts = {
-            h: self.val_hash_counts[h] for h in my_hashes[half_point:]
-        }
 
         # dereference each object
         # Find the objects with field_vals that hash to any of dumped_hashes
         # we will move their ids to the new bucket
         dumped_obj_ids = Int64Set()
-        for obj_id in self.obj_ids:
-            obj = obj_map.get(obj_id)
-            obj_val = get_field(obj, field)
-            if hash(obj_val) in dumped_hash_counts:
+        for val_hash in my_hashes[half_point:]:
+            for obj_id in val_hash_to_obj_ids[val_hash]:
                 dumped_obj_ids.add(obj_id)
                 self.obj_ids.remove(obj_id)
-        for dh in dumped_hash_counts:
-            del self.val_hash_counts[dh]
-        return dumped_hash_counts, dumped_obj_ids
+        return dumped_obj_ids, my_hashes[half_point], None
 
     def __len__(self):
         return len(self.obj_ids)
@@ -85,17 +90,14 @@ class DictBucket:
         val_hash: int,
         objs: Iterable[Any],
         obj_ids: Iterable[int],
-        vals: Optional[Iterable[Any]],
+        vals: Iterable[Any],
         field: Union[str, Callable],
     ):
         self.val_hash = val_hash
         self.d = dict()
         for i, obj_id in enumerate(obj_ids):
             obj = objs[i]
-            if vals is not None:
-                val = vals[i]
-            else:
-                val = get_field(obj, field)
+            val = vals[i]
             if val not in self.d:
                 self.d[val] = Int64Set()
             self.d[val].add(obj_id)

--- a/hashindex/mutable_buckets.py
+++ b/hashindex/mutable_buckets.py
@@ -36,7 +36,9 @@ class HashBucket:
 
     def remove(self, val_hash, obj_id):
         if val_hash not in self.val_hash_counts or self.val_hash_counts[val_hash] <= 0:
-            raise StaleObjectRemovalError(f'Cannot remove object (not found). Object was changed without using update().')
+            raise StaleObjectRemovalError(
+                f"Cannot remove object (not found). Object was changed without using update()."
+            )
         self.val_hash_counts[val_hash] -= 1
         if self.val_hash_counts[val_hash] == 0:
             del self.val_hash_counts[val_hash]
@@ -104,7 +106,9 @@ class DictBucket:
 
     def remove(self, val, obj_id):
         if val not in self.d or obj_id not in self.d[val]:
-            raise StaleObjectRemovalError("Cannot remove object (not found). Object was changed without using update().")
+            raise StaleObjectRemovalError(
+                "Cannot remove object (not found). Object was changed without using update()."
+            )
         self.d[val].remove(obj_id)
         if len(self.d[val]) == 0:
             del self.d[val]

--- a/hashindex/mutable_field.py
+++ b/hashindex/mutable_field.py
@@ -71,7 +71,9 @@ class MutableFieldIndex:
             # left and right sides.
             left_key, right_key = self.mbm.get_neighbors(db.val_hash)
             if right_key is None or right_key > db.val_hash + 1:
-                if right_key is not None and isinstance(self.mbm[right_key], HashBucket):
+                if right_key is not None and isinstance(
+                    self.mbm[right_key], HashBucket
+                ):
                     # just extend that bucket leftward to here
                     b = self.mbm.pop(right_key)
                     self.mbm[db.val_hash + 1] = b
@@ -81,13 +83,13 @@ class MutableFieldIndex:
             if db.val_hash > HASH_MIN:
                 if left_key is None:
                     self.mbm[HASH_MIN] = HashBucket()
-                elif left_key < db.val_hash - 1 and isinstance(self.mbm[left_key], DictBucket):
-                    self.mbm[left_key+1] = HashBucket()
+                elif left_key < db.val_hash - 1 and isinstance(
+                    self.mbm[left_key], DictBucket
+                ):
+                    self.mbm[left_key + 1] = HashBucket()
         else:
             # split it into two hashbuckets
-            new_hash_counts, new_obj_ids = self.mbm[k].split(
-                self.field, self.obj_map
-            )
+            new_hash_counts, new_obj_ids = self.mbm[k].split(self.field, self.obj_map)
             new_bucket = HashBucket()
             new_bucket.update(new_hash_counts, new_obj_ids)
             new_key = min(new_hash_counts.keys())
@@ -123,7 +125,10 @@ class MutableFieldIndex:
 
     def _add_plan_bucket(self, hash_pos: int, bp: BucketPlan):
         """Adds a bucket. Only used during init."""
-        if len(bp.distinct_hash_counts) == 1 and bp.distinct_hash_counts[0] > SIZE_THRESH:
+        if (
+            len(bp.distinct_hash_counts) == 1
+            and bp.distinct_hash_counts[0] > SIZE_THRESH
+        ):
             bucket_obj_ids = [id(obj) for obj in bp.obj_arr]
             b = DictBucket(
                 bp.distinct_hashes[0],
@@ -150,10 +155,10 @@ class MutableFieldIndex:
         next_needed = HASH_MIN
         for b in bucket_plans:
             mh = b.distinct_hashes[0]
-            btype = 'd' if sum(b.distinct_hash_counts) > SIZE_THRESH else 'h'
+            btype = "d" if sum(b.distinct_hash_counts) > SIZE_THRESH else "h"
             # resolve any gaps
             if next_needed is not None and mh > next_needed:
-                if btype == 'h':
+                if btype == "h":
                     # expand this bucket to the left
                     mh = next_needed
                 else:
@@ -161,7 +166,7 @@ class MutableFieldIndex:
                     self._add_plan_bucket(next_needed, empty_plan())
             # add this bucket
             self._add_plan_bucket(mh, b)
-            if btype == 'd' and mh < HASH_MAX:
+            if btype == "d" and mh < HASH_MAX:
                 next_needed = mh + 1
             else:
                 next_needed = None

--- a/hashindex/utils.py
+++ b/hashindex/utils.py
@@ -14,16 +14,6 @@ def get_field(obj, field):
     return val
 
 
-def set_field(obj, field, new_value):
-    if callable(field):
-        # update() removes and re-adds the object. Callables are re-evaluated during add(). So, nothing to do here.
-        return
-    elif isinstance(obj, dict):
-        obj[field] = new_value
-    else:
-        setattr(obj, field, new_value)
-
-
 def get_attributes(cls) -> List[str]:
     """Helper function to grab the attributes of a class"""
     return list(cls.__annotations__.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hashindex"
-version = "0.5.0"
+version = "0.5.1"
 description = "Find Python objects by exact match on their attributes."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/run_test_cov.sh
+++ b/run_test_cov.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Generate a fresh coverage report. Requires pytest-cov.
+pytest --cov-report term --cov=hashindex test/ | tee test/cov.txt
+

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@ class AssertRaises:
     While the unittest package has an assertRaises context manager, it is incompatible with pytest + fixtures.
     Cleaner to just implement an AssertRaises here.
     """
+
     def __init__(self, exc_type):
         self.exc_type = exc_type
 

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -1,0 +1,39 @@
+============================= test session starts ==============================
+platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+rootdir: /home/theo/repos
+plugins: anyio-2.2.0, cov-3.0.0
+collected 129 items
+
+test/test_basic_operations.py ..................                         [ 13%]
+test/test_container_ops.py ............                                  [ 23%]
+test/test_edge_cases.py ...................                              [ 37%]
+test/test_examples.py ..                                                 [ 39%]
+test/test_exceptions.py ........                                         [ 45%]
+test/test_fancy_gets.py ............                                     [ 55%]
+test/test_field.py ..............                                        [ 65%]
+test/test_hash_collisions.py ..........                                  [ 73%]
+test/test_init_helpers.py .....                                          [ 77%]
+test/test_mutable_bucket_manager.py ...................                  [ 92%]
+test/test_soak.py .                                                      [ 93%]
+test/test_stale_objects.py .........                                     [100%]
+
+----------- coverage: platform linux, python 3.9.7-final-0 -----------
+Name                                  Stmts   Miss  Cover
+---------------------------------------------------------
+hashindex/__init__.py                     2      0   100%
+hashindex/constants.py                    5      0   100%
+hashindex/exceptions.py                  10      0   100%
+hashindex/frozen.py                      63      0   100%
+hashindex/frozen_buckets.py             104      0   100%
+hashindex/frozen_field.py                50      0   100%
+hashindex/init_helpers.py                66      0   100%
+hashindex/mutable.py                     77      0   100%
+hashindex/mutable_bucket_manager.py      48      0   100%
+hashindex/mutable_buckets.py             69      0   100%
+hashindex/mutable_field.py               95      0   100%
+hashindex/utils.py                       25      0   100%
+---------------------------------------------------------
+TOTAL                                   614      0   100%
+
+
+============================= 129 passed in 6.25s ==============================

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -2,20 +2,20 @@
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
 rootdir: /home/theo/repos
 plugins: anyio-2.2.0, cov-3.0.0
-collected 129 items
+collected 127 items
 
-test/test_basic_operations.py ..................                         [ 13%]
+test/test_basic_operations.py ..................                         [ 14%]
 test/test_container_ops.py ............                                  [ 23%]
-test/test_edge_cases.py ...................                              [ 37%]
-test/test_examples.py ..                                                 [ 39%]
-test/test_exceptions.py ........                                         [ 45%]
+test/test_edge_cases.py ...................                              [ 38%]
+test/test_examples.py ..                                                 [ 40%]
+test/test_exceptions.py ........                                         [ 46%]
 test/test_fancy_gets.py ............                                     [ 55%]
-test/test_field.py ..............                                        [ 65%]
-test/test_hash_collisions.py ..........                                  [ 73%]
-test/test_init_helpers.py .....                                          [ 77%]
-test/test_mutable_bucket_manager.py ...................                  [ 92%]
-test/test_soak.py .                                                      [ 93%]
-test/test_stale_objects.py .........                                     [100%]
+test/test_field.py ..............                                        [ 66%]
+test/test_hash_collisions.py ..........                                  [ 74%]
+test/test_init_helpers.py .....                                          [ 78%]
+test/test_mutable_bucket_manager.py ...................                  [ 93%]
+test/test_soak.py .                                                      [ 94%]
+test/test_stale_objects.py .......                                       [100%]
 
 ----------- coverage: platform linux, python 3.9.7-final-0 -----------
 Name                                  Stmts   Miss  Cover
@@ -29,11 +29,11 @@ hashindex/frozen_field.py                50      0   100%
 hashindex/init_helpers.py                66      0   100%
 hashindex/mutable.py                     77      0   100%
 hashindex/mutable_bucket_manager.py      48      0   100%
-hashindex/mutable_buckets.py             69      0   100%
-hashindex/mutable_field.py               95      0   100%
+hashindex/mutable_buckets.py             63      0   100%
+hashindex/mutable_field.py               93      0   100%
 hashindex/utils.py                       25      0   100%
 ---------------------------------------------------------
-TOTAL                                   614      0   100%
+TOTAL                                   606      0   100%
 
 
-============================= 129 passed in 6.25s ==============================
+============================= 127 passed in 6.18s ==============================

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -96,21 +96,6 @@ def test_remove(index_type):
         assert len(one_chu) == 1
 
 
-def test_update(index_type):
-    hi = make_test_data(index_type)
-    eevee = hi.find({"name": "Eevee"})[0]
-    update = {"name": "Glaceon", "type1": "Ice", "type2": None}
-    if index_type == FrozenHashIndex:
-        with AssertRaises(AttributeError):
-            hi.update(eevee, update)
-    else:
-        hi.update(eevee, update)
-        res_eevee = hi.find({"name": "Eevee"})
-        res_glaceon = hi.find({"name": "Glaceon"})
-        assert not res_eevee
-        assert res_glaceon
-
-
 def test_add(index_type):
     hi = make_test_data(index_type)
     glaceon = Pokemon("Glaceon", "Ice", None)

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -71,18 +71,14 @@ def test_three_fields(index_type):
 
 def test_exclude_all(index_type):
     hi = make_test_data(index_type)
-    result = hi.find(
-        exclude={"type1": ["Electric", "Normal"]}
-    )
+    result = hi.find(exclude={"type1": ["Electric", "Normal"]})
     assert len(result) == 0
 
 
 def test_find_ids(index_type):
-    data = [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]
-    hi = index_type(data, ['a', 'b'])
-    result = hi.find_ids(
-        {"b": 4}
-    )
+    data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+    hi = index_type(data, ["a", "b"])
+    result = hi.find_ids({"b": 4})
     res_id = next(iter(result))
     assert res_id == id(data[1])
 
@@ -125,4 +121,3 @@ def test_add(index_type):
         hi.add(glaceon)
         res = hi.find({"name": "Glaceon"})
         assert res == [glaceon]
-

--- a/test/test_container_ops.py
+++ b/test/test_container_ops.py
@@ -4,8 +4,8 @@ from hashindex.constants import SIZE_THRESH
 
 
 def test_iter_small(index_type):
-    ls = [{'i': i} for i in range(5)]
-    hi = index_type(ls, ['i'])
+    ls = [{"i": i} for i in range(5)]
+    hi = index_type(ls, ["i"])
     assert len(hi) == len(ls)
     hi_ls = list(hi)
     assert len(hi_ls) == len(ls)
@@ -14,13 +14,10 @@ def test_iter_small(index_type):
     assert len(hi_ls) == len(ls)
 
 
-@pytest.mark.parametrize('idx_order', [
-    ['i', 'j'],
-    ['j', 'i'],
-])
+@pytest.mark.parametrize("idx_order", [["i", "j"], ["j", "i"],])
 def test_iter_large(index_type, idx_order):
-    ls = [{'i': i, 'j': -(i % 3)} for i in range(SIZE_THRESH*3+3)]
-    ls += [{'j': 16}]  # make sure there's at least one hashbucket
+    ls = [{"i": i, "j": -(i % 3)} for i in range(SIZE_THRESH * 3 + 3)]
+    ls += [{"j": 16}]  # make sure there's at least one hashbucket
     hi = index_type(ls, idx_order)
     assert len(hi) == len(ls)
     hi_ls = list(hi)
@@ -30,21 +27,18 @@ def test_iter_large(index_type, idx_order):
     assert len(hi_ls) == len(ls)
 
 
-@pytest.mark.parametrize('idx_order', [
-    ['i', 'j'],
-    ['j', 'i'],
-])
+@pytest.mark.parametrize("idx_order", [["i", "j"], ["j", "i"],])
 def test_make_from(index_type, idx_order):
     """See if we can make one index type from the other type."""
     make_type = HashIndex if index_type == FrozenHashIndex else FrozenHashIndex
-    ls = [{'i': i, 'j': -(i % 3)} for i in range(SIZE_THRESH*3+3)]
+    ls = [{"i": i, "j": -(i % 3)} for i in range(SIZE_THRESH * 3 + 3)]
     hi = index_type(ls, on=idx_order)
     other_hi = make_type(hi, on=idx_order)
     assert len(other_hi) == len(hi)
 
 
 def test_contains(index_type):
-    ls = [{'i': i} for i in range(5)]
-    hi = index_type(ls, ['i'])
+    ls = [{"i": i} for i in range(5)]
+    hi = index_type(ls, ["i"])
     for item in ls:
         assert item in hi

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -16,29 +16,32 @@ class EdgeHash:
         return self.x == other.x
 
 
-@pytest.mark.parametrize('n_items', [SIZE_THRESH*3+3, 15])
+@pytest.mark.parametrize("n_items", [SIZE_THRESH * 3 + 3, 15])
 def test_edge_hash(index_type, n_items):
-    hi = index_type([{'z': EdgeHash(i % 3)} for i in range(n_items)], ['z'])
-    assert len(hi.find({'z': EdgeHash(0)})) == n_items // 3
-    assert len(hi.find({'z': EdgeHash(1)})) == n_items // 3
-    assert len(hi.find({'z': EdgeHash(2)})) == n_items // 3
+    hi = index_type([{"z": EdgeHash(i % 3)} for i in range(n_items)], ["z"])
+    assert len(hi.find({"z": EdgeHash(0)})) == n_items // 3
+    assert len(hi.find({"z": EdgeHash(1)})) == n_items // 3
+    assert len(hi.find({"z": EdgeHash(2)})) == n_items // 3
 
 
-@pytest.mark.parametrize('n_items,delete_bucket', [
-    (SIZE_THRESH*3+3, 0),
-    (SIZE_THRESH*3+3, 1),
-    (SIZE_THRESH*3+3, 2),
-    (15, 0),
-    (15, 1),
-    (15, 2),
-])
+@pytest.mark.parametrize(
+    "n_items,delete_bucket",
+    [
+        (SIZE_THRESH * 3 + 3, 0),
+        (SIZE_THRESH * 3 + 3, 1),
+        (SIZE_THRESH * 3 + 3, 2),
+        (15, 0),
+        (15, 1),
+        (15, 2),
+    ],
+)
 def test_edge_hash_mutable(n_items, delete_bucket):
     """Ensure there are no problems creating / destroying buckets at the extrema of the hash space."""
     arrs = [list(), list(), list()]
     for i in range(n_items):
-        arrs[i % 3].append({'z': EdgeHash(i % 3)})
+        arrs[i % 3].append({"z": EdgeHash(i % 3)})
 
-    hi = HashIndex(on=['z'])
+    hi = HashIndex(on=["z"])
     for arr in arrs:
         for obj in arr:
             hi.add(obj)
@@ -66,13 +69,13 @@ class GroupedHash:
         return self.x == other.x
 
 
-@pytest.mark.parametrize('delete_bucket', [0, 1, 2])
+@pytest.mark.parametrize("delete_bucket", [0, 1, 2])
 def test_grouped_hash(delete_bucket):
     arrs = [list(), list(), list()]
-    for i in range(SIZE_THRESH*3+3):
-        arrs[i%3].append({'z': GroupedHash(i%3)})
+    for i in range(SIZE_THRESH * 3 + 3):
+        arrs[i % 3].append({"z": GroupedHash(i % 3)})
 
-    hi = HashIndex(on=['z'])
+    hi = HashIndex(on=["z"])
     for arr in arrs:
         for gh in arr:
             hi.add(gh)
@@ -83,9 +86,9 @@ def test_grouped_hash(delete_bucket):
 
     for b in range(3):
         if b == delete_bucket:
-            assert len(hi.find({'z': GroupedHash(b)})) == 0
+            assert len(hi.find({"z": GroupedHash(b)})) == 0
         else:
-            assert len(hi.find({'z': GroupedHash(b)})) == SIZE_THRESH+1
+            assert len(hi.find({"z": GroupedHash(b)})) == SIZE_THRESH + 1
 
 
 def test_get_zero(index_type):
@@ -98,22 +101,22 @@ def test_get_zero(index_type):
 
 
 def test_add_none():
-    hi = HashIndex(on='s')
+    hi = HashIndex(on="s")
     hi.add(None)
-    result = hi.find({'s': None})
+    result = hi.find({"s": None})
     assert result[0] is None
 
 
 def test_double_add():
-    hi = HashIndex(on='s')
-    x = {'s': 'hello'}
+    hi = HashIndex(on="s")
+    x = {"s": "hello"}
     hi.add(x)
     hi.add(x)
     assert len(hi) == 1
-    assert hi.find({'s': 'hello'}) == [x]
+    assert hi.find({"s": "hello"}) == [x]
     hi.remove(x)
     assert len(hi) == 0
-    assert hi.find({'s': 'hello'}) == []
+    assert hi.find({"s": "hello"}) == []
 
 
 def test_empty_mutable_index():
@@ -124,17 +127,17 @@ def test_empty_mutable_index():
 
 def test_update_callable():
     """When using update(), Callable indices don't need updating. If you do, it'll just be ignored."""
-    data = [{'a': 1.2}]
-    f = lambda x: round(x['a'])
+    data = [{"a": 1.2}]
+    f = lambda x: round(x["a"])
     hi = HashIndex(data, [f])
-    hi.update(data[0], {'a': 2.2})
+    hi.update(data[0], {"a": 2.2})
     assert len(hi.find({f: 2})) == 1
-    hi.update(data[0], {'a': 3.2, f: 5})
+    hi.update(data[0], {"a": 3.2, f: 5})
     assert len(hi.find({f: 3})) == 1
     assert len(hi.find({f: 5})) == 0
 
 
 def test_arg_order():
-    data = [{'a': i % 5, 'b': i % 3} for i in range(100)]
-    hi = HashIndex(data, ['a', 'b'])
-    assert len(hi.find({'a': 1, 'b': 2})) == len(hi.find({'b': 2, 'a': 1}))
+    data = [{"a": i % 5, "b": i % 3} for i in range(100)]
+    hi = HashIndex(data, ["a", "b"])
+    assert len(hi.find({"a": 1, "b": 2})) == len(hi.find({"b": 2, "a": 1}))

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -125,18 +125,6 @@ def test_empty_mutable_index():
     assert len(result) == 0
 
 
-def test_update_callable():
-    """When using update(), Callable indices don't need updating. If you do, it'll just be ignored."""
-    data = [{"a": 1.2}]
-    f = lambda x: round(x["a"])
-    hi = HashIndex(data, [f])
-    hi.update(data[0], {"a": 2.2})
-    assert len(hi.find({f: 2})) == 1
-    hi.update(data[0], {"a": 3.2, f: 5})
-    assert len(hi.find({f: 3})) == 1
-    assert len(hi.find({f: 5})) == 0
-
-
 def test_arg_order():
     data = [{"a": i % 5, "b": i % 3} for i in range(100)]
     hi = HashIndex(data, ["a", "b"])

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2,7 +2,7 @@ import random
 
 
 def test_get_nearby(index_type):
-    t = {(random.random()*10, random.random()*10) for _ in range(10**4)}
+    t = {(random.random() * 10, random.random() * 10) for _ in range(10 ** 4)}
 
     def _x(obj):
         return int(obj[0])
@@ -13,4 +13,3 @@ def test_get_nearby(index_type):
     hi = index_type(t, [_x, _y])
     for pt in hi.find({_x: 0, _y: 0}):
         assert _x(pt) < 1 and _y(pt) < 1
-

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -44,15 +44,3 @@ def test_remove_missing_value(n_items):
     with AssertRaises(MissingObjectError):
         hi.remove(BadHash(-1))
 
-
-@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
-def test_update_missing_value(n_items):
-    """
-    When the value hashes to a bucket, but the bucket does not contain the value, is
-    an empty result correctly retrieved?
-    """
-    data = [BadHash(i) for i in range(n_items)]
-    hi = HashIndex(data, ["n"])
-    assert len(hi.find({"n": -1})) == 0
-    with AssertRaises(MissingObjectError):
-        hi.update(BadHash(-1), {"n": 3})

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -19,40 +19,40 @@ def test_empty_frozen():
 
 def test_no_index_mutable(index_type):
     with AssertRaises(ValueError):
-        index_type(['a'])
+        index_type(["a"])
 
 
 def test_bad_query(index_type):
-    hi = index_type([0], on=['a'])
+    hi = index_type([0], on=["a"])
     with AssertRaises(TypeError):
         hi.find(match=[])
     with AssertRaises(TypeError):
-        hi.find(['a', 1])
+        hi.find(["a", 1])
     with AssertRaises(MissingIndexError):
-        hi.find({'b': 1})
+        hi.find({"b": 1})
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH+1])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
 def test_remove_missing_value(n_items):
     """
     When the value hashes to a bucket, but the bucket does not contain the value, is
     an empty result correctly retrieved?
     """
     data = [BadHash(i) for i in range(5)]
-    hi = HashIndex(data, ['n'])
-    assert len(hi.find({'n': -1})) == 0
+    hi = HashIndex(data, ["n"])
+    assert len(hi.find({"n": -1})) == 0
     with AssertRaises(MissingObjectError):
         hi.remove(BadHash(-1))
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH+1])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
 def test_update_missing_value(n_items):
     """
     When the value hashes to a bucket, but the bucket does not contain the value, is
     an empty result correctly retrieved?
     """
     data = [BadHash(i) for i in range(n_items)]
-    hi = HashIndex(data, ['n'])
-    assert len(hi.find({'n': -1})) == 0
+    hi = HashIndex(data, ["n"])
+    assert len(hi.find({"n": -1})) == 0
     with AssertRaises(MissingObjectError):
-        hi.update(BadHash(-1), {'n': 3})
+        hi.update(BadHash(-1), {"n": 3})

--- a/test/test_fancy_gets.py
+++ b/test/test_fancy_gets.py
@@ -34,17 +34,17 @@ def test_getter_fn(index_type):
     assert result == [dicts[2]]
 
 
-@pytest.mark.parametrize('n', [SIZE_THRESH + 1, 5])
+@pytest.mark.parametrize("n", [SIZE_THRESH + 1, 5])
 def test_get_all(index_type, n):
     """There's a special fast-path when all items are being retrieved."""
-    hi = index_type([{'a': 1} for _ in range(n)], ['a'])
+    hi = index_type([{"a": 1} for _ in range(n)], ["a"])
     result = hi.find()
     assert len(result) == n
 
 
-@pytest.mark.parametrize('n', [SIZE_THRESH + 1, 5])
+@pytest.mark.parametrize("n", [SIZE_THRESH + 1, 5])
 def test_get_all_ids(index_type, n):
     """There's a special fast-path when all ids are being retrieved."""
-    hi = index_type([{'a': 1} for _ in range(n)], ['a'])
+    hi = index_type([{"a": 1} for _ in range(n)], ["a"])
     result = hi.find_ids()
     assert len(result) == n

--- a/test/test_hash_collisions.py
+++ b/test/test_hash_collisions.py
@@ -4,15 +4,16 @@ from hashindex.constants import SIZE_THRESH
 from .conftest import BadHash, TwoHash
 from hashindex import HashIndex
 
+
 def test_dict_bucket_collision(index_type):
     """
     Ensure the DictBuckets still work properly under hash collision.
     """
-    items_1 = [BadHash(1) for _ in range(SIZE_THRESH+1)]
-    items_2 = [BadHash(2) for _ in range(SIZE_THRESH+2)]
-    hi = index_type(items_1+items_2, ['n'])
-    found_1 = hi.find({'n': 1})
-    found_2 = hi.find({'n': 2})
+    items_1 = [BadHash(1) for _ in range(SIZE_THRESH + 1)]
+    items_2 = [BadHash(2) for _ in range(SIZE_THRESH + 2)]
+    hi = index_type(items_1 + items_2, ["n"])
+    found_1 = hi.find({"n": 1})
+    found_2 = hi.find({"n": 2})
     assert len(found_1) == len(items_1)
     assert len(found_2) == len(items_2)
     assert all([o.n == 1 for o in found_1])
@@ -25,30 +26,30 @@ def test_hash_bucket_collision(index_type):
     """
     items_1 = [BadHash(1) for _ in range(5)]
     items_2 = [BadHash(2) for _ in range(6)]
-    hi = index_type(items_1+items_2, ['n'])
-    found_1 = hi.find({'n': 1})
-    found_2 = hi.find({'n': 2})
+    hi = index_type(items_1 + items_2, ["n"])
+    found_1 = hi.find({"n": 1})
+    found_2 = hi.find({"n": 2})
     assert len(found_1) == len(items_1)
     assert len(found_2) == len(items_2)
     assert all([o.n == 1 for o in found_1])
     assert all([o.n == 2 for o in found_2])
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH+1])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
 def test_get_missing_value(index_type, n_items):
     """
     When the value hashes to a bucket, but the bucket does not contain the value, is
     an empty result correctly retrieved?
     """
     data = [BadHash(i) for i in range(n_items)]
-    hi = index_type(data, ['n'])
-    assert len(hi.find({'n': -1})) == 0
+    hi = index_type(data, ["n"])
+    assert len(hi.find({"n": -1})) == 0
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH+1])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
 def test_add_remove_two_hashes_uneven(n_items):
     data = [TwoHash(0) for _ in range(n_items)] + [TwoHash(1) for _ in range(5)]
-    hi = HashIndex(on=['n'])
+    hi = HashIndex(on=["n"])
     for d in data:
         hi.add(d)
     for d in data:

--- a/test/test_mutable_bucket_manager.py
+++ b/test/test_mutable_bucket_manager.py
@@ -7,15 +7,16 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "keys,query,result", [
+    "keys,query,result",
+    [
         ([1], 1, (None, None)),
         ([1, 2, 3], 2, (1, 3)),
         ([3, 2, 1], 2, (1, 3)),
         ([0, -20, -10], -10, (-20, 0)),
         ([HASH_MIN, 0, HASH_MAX], 0, (HASH_MIN, HASH_MAX)),
         ([HASH_MIN], HASH_MIN, (None, None)),
-        ([HASH_MAX], HASH_MAX, (None, None))
-    ]
+        ([HASH_MAX], HASH_MAX, (None, None)),
+    ],
 )
 def test_get_neighbors(keys, query, result):
     mb = MutableBucketManager()
@@ -25,7 +26,8 @@ def test_get_neighbors(keys, query, result):
 
 
 @pytest.mark.parametrize(
-    "keys,query,result", [
+    "keys,query,result",
+    [
         ([1], 1, 1),
         ([1], 2, 1),
         ([1], HASH_MAX, 1),
@@ -34,7 +36,7 @@ def test_get_neighbors(keys, query, result):
         ([HASH_MIN], HASH_MAX, HASH_MIN),
         ([1, 2], 1, 1),
         ([1, 2], 2, 2),
-    ]
+    ],
 )
 def test_get_bucket_key_for(keys, query, result):
     mb = MutableBucketManager()
@@ -45,32 +47,37 @@ def test_get_bucket_key_for(keys, query, result):
 
 
 @pytest.mark.parametrize(
-    "keys,query,result", [
+    "keys,query,result",
+    [
         ([1], 2, 1),
         ([1], 1, 1),
         ([1, 3, 4], 2, 1),
         ([1, 3, 4], 1, 1),
         ([1, 3, 4], 4, 4),
         ([1, 3, 4], 5, 4),
-    ])
+    ],
+)
 def test_sorted_dict_bisect(keys, query, result):
     sd = SortedDict()
     for i, k in enumerate(keys):
         sd[k] = random.random()
-    idx = sd.bisect_right(query)-1
+    idx = sd.bisect_right(query) - 1
     item, _ = sd.peekitem(idx)
     assert item == result
 
 
-@pytest.mark.parametrize('buckets,query,result', [
-    ([], 0, (None, None)),
-    ([0], 0, (None, None)),
-    ([0, 1], 0, (None, 1)),
-    ([0, 1], 1, (0, None)),
-    ([0, 1, 2], 1, (0, 2)),
-])
+@pytest.mark.parametrize(
+    "buckets,query,result",
+    [
+        ([], 0, (None, None)),
+        ([0], 0, (None, None)),
+        ([0, 1], 0, (None, 1)),
+        ([0, 1], 1, (0, None)),
+        ([0, 1, 2], 1, (0, 2)),
+    ],
+)
 def test_get_neighbors(buckets, query, result):
     mb = MutableBucketManager()
     for b in buckets:
-        mb.buckets[b] = 'bucket'
+        mb.buckets[b] = "bucket"
     assert mb.get_neighbors(query) == result

--- a/test/test_soak.py
+++ b/test/test_soak.py
@@ -10,14 +10,16 @@ from hashindex import HashIndex
 from hashindex.utils import get_field, set_field
 
 
-PLANETS = ['mercury'] * 1 + \
-          ['venus'] * 2 + \
-          ['earth'] * 4 + \
-          ['mars'] * 8 + \
-          ['jupiter'] * 16 + \
-          ['saturn'] * 32 + \
-          ['uranus'] * 64 + \
-          ['neptune'] * 128
+PLANETS = (
+    ["mercury"] * 1
+    + ["venus"] * 2
+    + ["earth"] * 4
+    + ["mars"] * 8
+    + ["jupiter"] * 16
+    + ["saturn"] * 32
+    + ["uranus"] * 64
+    + ["neptune"] * 128
+)
 
 
 class Collider:
@@ -47,7 +49,7 @@ class Thing:
 
 def planet_len(obj):
     if isinstance(obj, dict):
-        return len(obj['planet'])
+        return len(obj["planet"])
     else:
         return len(obj.planet)
 
@@ -55,12 +57,12 @@ def planet_len(obj):
 def make_dict_thing(id_num):
     t = Thing(id_num)
     return {
-        'id_num': t.id_num,
-        'ts_sec': t.ts_sec,
-        'ts': t.ts,
-        'planet': t.planet,
-        'collider': t.collider,
-        planet_len: planet_len(t)
+        "id_num": t.id_num,
+        "ts_sec": t.ts_sec,
+        "ts": t.ts,
+        "planet": t.planet,
+        "collider": t.collider,
+        planet_len: planet_len(t),
     }
 
 
@@ -69,21 +71,33 @@ class SoakTest:
     Keep running insert / update / remove operations at random for a long time.
     Check periodically to make sure find() results are correct.
     """
+
     def __init__(self):
         self.t0 = time.time()
-        self.t_report = set([5*i for i in range(1000)])
+        self.t_report = set([5 * i for i in range(1000)])
         random.seed(time.time())
-        self.seed = random.choice(range(10**6))
-        print('running soak test with seed:', self.seed)
+        self.seed = random.choice(range(10 ** 6))
+        print("running soak test with seed:", self.seed)
         random.seed(self.seed)
-        self.hi = HashIndex(on=['ts_sec', 'ts', 'planet', 'collider', 'sometimes', planet_len])
+        self.hi = HashIndex(
+            on=["ts_sec", "ts", "planet", "collider", "sometimes", planet_len]
+        )
         #  self.hi = HashIndex(on=[planet_len])
         self.objs = dict()
         self.max_id_num = 0
 
     def run(self, duration):
         while time.time() - self.t0 < duration:
-            op = random.choice([self.add, self.add_many, self.update, self.remove, self.remove_all, self.check_equal])
+            op = random.choice(
+                [
+                    self.add,
+                    self.add_many,
+                    self.update,
+                    self.remove,
+                    self.remove_all,
+                    self.check_equal,
+                ]
+            )
             op()
 
     def add(self):
@@ -116,12 +130,15 @@ class SoakTest:
         t = self.random_obj()
         if t is not None:
             t_new = Thing(-1)
-            self.hi.update(t, {
-                'planet': t_new.planet,
-                planet_len: planet_len(t_new),
-                'ts': t_new.ts,
-                'ts_sec': t_new.ts_sec,
-            })
+            self.hi.update(
+                t,
+                {
+                    "planet": t_new.planet,
+                    planet_len: planet_len(t_new),
+                    "ts": t_new.ts,
+                    "ts_sec": t_new.ts_sec,
+                },
+            )
 
     def random_obj(self):
         if not len(self.objs):
@@ -130,28 +147,28 @@ class SoakTest:
 
     def check_equal(self):
         # check a string key
-        ls = [o for o in self.objs.values() if get_field(o, 'planet') == 'saturn']
-        hi_ls = self.hi.find({'planet': 'saturn'})
+        ls = [o for o in self.objs.values() if get_field(o, "planet") == "saturn"]
+        hi_ls = self.hi.find({"planet": "saturn"})
         assert len(ls) == len(hi_ls)
         # check a functional key
         ls = [o for o in self.objs.values() if get_field(o, planet_len) == 6]
         hi_ls = self.hi.find({planet_len: 6})
         assert len(ls) == len(hi_ls)
         # check a null-ish key
-        ls = [o for o in self.objs.values() if get_field(o, 'sometimes') is None]
-        hi_ls = self.hi.find({'sometimes': None})
+        ls = [o for o in self.objs.values() if get_field(o, "sometimes") is None]
+        hi_ls = self.hi.find({"sometimes": None})
         assert len(ls) == len(hi_ls)
         # check a colliding key
         c = Collider()
-        ls = [o for o in self.objs.values() if get_field(o, 'collider') == c]
-        hi_ls = self.hi.find({'collider': c})
+        ls = [o for o in self.objs.values() if get_field(o, "collider") == c]
+        hi_ls = self.hi.find({"collider": c})
         assert len(ls) == len(hi_ls)
         # check an object-ish key
         t = self.random_obj()
         if t is not None:
-            target_ts = get_field(t, 'ts_sec')
-            ls = [o for o in self.objs.values() if get_field(o, 'ts_sec') == target_ts]
-            hi_ls = self.hi.find({'ts_sec': target_ts})
+            target_ts = get_field(t, "ts_sec")
+            ls = [o for o in self.objs.values() if get_field(o, "ts_sec") == target_ts]
+            hi_ls = self.hi.find({"ts_sec": target_ts})
             assert len(ls) == len(hi_ls)
 
 

--- a/test/test_soak.py
+++ b/test/test_soak.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 import random
 from hashindex import HashIndex
-from hashindex.utils import get_field, set_field
+from hashindex.utils import get_field
 
 
 PLANETS = (
@@ -92,7 +92,6 @@ class SoakTest:
                 [
                     self.add,
                     self.add_many,
-                    self.update,
                     self.remove,
                     self.remove_all,
                     self.check_equal,
@@ -125,20 +124,6 @@ class SoakTest:
         for t in self.objs.values():
             self.hi.remove(t)
         self.objs = dict()
-
-    def update(self):
-        t = self.random_obj()
-        if t is not None:
-            t_new = Thing(-1)
-            self.hi.update(
-                t,
-                {
-                    "planet": t_new.planet,
-                    planet_len: planet_len(t_new),
-                    "ts": t_new.ts,
-                    "ts_sec": t_new.ts_sec,
-                },
-            )
 
     def random_obj(self):
         if not len(self.objs):

--- a/test/test_stale_objects.py
+++ b/test/test_stale_objects.py
@@ -5,42 +5,41 @@ from .conftest import BadHash, TwoHash, AssertRaises
 from hashindex.exceptions import StaleObjectRemovalError, MissingObjectError
 
 
-
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH+1])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH + 1])
 def test_get_stale_objects(index_type, n_items):
-    objs = [{'z': BadHash(1)} for _ in range(n_items)]
-    hi = index_type(objs, ['z'])
+    objs = [{"z": BadHash(1)} for _ in range(n_items)]
+    hi = index_type(objs, ["z"])
     for o in objs:
-        o['z'] = BadHash(2)  # updated without calling update()
-    found = hi.find({'z': BadHash(1)})
+        o["z"] = BadHash(2)  # updated without calling update()
+    found = hi.find({"z": BadHash(1)})
     assert len(found) == 0
-    found = hi.find({'z': BadHash(2)})
+    found = hi.find({"z": BadHash(2)})
     assert len(found) == 0
 
 
-@pytest.mark.parametrize('n_items', [SIZE_THRESH*2+2])
+@pytest.mark.parametrize("n_items", [SIZE_THRESH * 2 + 2])
 def test_remove_stale_objects_one_hash(n_items):
-    objs = [{'z': BadHash(0)} for _ in range(n_items)]
-    hi = HashIndex(objs, ['z'])
+    objs = [{"z": BadHash(0)} for _ in range(n_items)]
+    hi = HashIndex(objs, ["z"])
     for o in objs:
-        o['z'] = BadHash(1)  # updated without calling update()
+        o["z"] = BadHash(1)  # updated without calling update()
     with AssertRaises(StaleObjectRemovalError):
         hi.remove(objs[0])
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH*2+2])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH * 2 + 2])
 def test_remove_stale_objects_two_hash(n_items):
-    objs = [{'z': TwoHash(0)} for _ in range(n_items)]
-    hi = HashIndex(objs, ['z'])
+    objs = [{"z": TwoHash(0)} for _ in range(n_items)]
+    hi = HashIndex(objs, ["z"])
     for o in objs:
-        o['z'] = TwoHash(1)  # updated without calling update()
+        o["z"] = TwoHash(1)  # updated without calling update()
     with AssertRaises(StaleObjectRemovalError):
         hi.remove(objs[0])
 
 
-@pytest.mark.parametrize('n_items', [5, SIZE_THRESH*2+2])
+@pytest.mark.parametrize("n_items", [5, SIZE_THRESH * 2 + 2])
 def test_remove_missing_object(n_items):
-    objs = [{'z': TwoHash(1)} for _ in range(n_items)]
-    hi = HashIndex(objs, ['z'])
+    objs = [{"z": TwoHash(1)} for _ in range(n_items)]
+    hi = HashIndex(objs, ["z"])
     with AssertRaises(MissingObjectError):
         hi.remove(TwoHash(2))

--- a/test/test_stale_objects.py
+++ b/test/test_stale_objects.py
@@ -28,16 +28,6 @@ def test_remove_stale_objects_one_hash(n_items):
 
 
 @pytest.mark.parametrize("n_items", [5, SIZE_THRESH * 2 + 2])
-def test_remove_stale_objects_two_hash(n_items):
-    objs = [{"z": TwoHash(0)} for _ in range(n_items)]
-    hi = HashIndex(objs, ["z"])
-    for o in objs:
-        o["z"] = TwoHash(1)  # updated without calling update()
-    with AssertRaises(StaleObjectRemovalError):
-        hi.remove(objs[0])
-
-
-@pytest.mark.parametrize("n_items", [5, SIZE_THRESH * 2 + 2])
 def test_remove_missing_object(n_items):
     objs = [{"z": TwoHash(1)} for _ in range(n_items)]
     hi = HashIndex(objs, ["z"])


### PR DESCRIPTION
In release 0.5.0, HashIndex's HashBucket class had a needless Int64ToInt64Map that was taking up some 60-70 bytes per object on high-cardinality data.

This had the effect that the HashIndex used far more memory than needed. This PR fixes the bug, and is the reason for the 0.5.1 release. 